### PR TITLE
Add seek_callback

### DIFF
--- a/archive/Archive.ml
+++ b/archive/Archive.ml
@@ -14,7 +14,14 @@ module Read = struct
       * ('a, 'b) ArchiveLow.open_callback
       * 'b ArchiveLow.read_callback
       * 'b ArchiveLow.skip_callback
-      * 'b ArchiveLow.close_callback ]
+      * 'b ArchiveLow.close_callback
+    | `Callback_seekable of
+      'a
+      * ('a, 'b) ArchiveLow.open_callback
+      * 'b ArchiveLow.read_callback
+      * 'b ArchiveLow.skip_callback
+      * 'b ArchiveLow.close_callback
+      * 'b ArchiveLow.seek_callback ]
 
   type ('a, 'b) t = {
     ard_input : ('a, 'b) input;
@@ -30,6 +37,9 @@ module Read = struct
         match input with
         | `Filename fn -> ArchiveLow.Read.open_filename hdl fn 4096
         | `Callback (data, open_cbk, read_cbk, skip_cbk, close_cbk) ->
+            ArchiveLow.Read.open2 hdl open_cbk read_cbk skip_cbk close_cbk data
+        | `Callback_seekable (data, open_cbk, read_cbk, skip_cbk, close_cbk, seek_cbk) ->
+            ArchiveLow.Read.Unsafe.set_seek_callback hdl seek_cbk;
             ArchiveLow.Read.open2 hdl open_cbk read_cbk skip_cbk close_cbk data
       in
       let res = f hdl in

--- a/archive/Archive.mli
+++ b/archive/Archive.mli
@@ -19,7 +19,15 @@ module Read : sig
       * 'b read_callback
       * 'b skip_callback
       * 'b close_callback
-      (** Use callbacks and archive_read_open2 to create the archive *)
+      (** Use callbacks to create an archive from a logical stream *)
+    | `Callback_seekable of
+      'a
+      * ('a, 'b) open_callback
+      * 'b read_callback
+      * 'b skip_callback
+      * 'b close_callback
+      * 'b seek_callback
+      (** Use callbacks to create an archive from a seekable object *)
     | `Filename of filename  (** Use a filename to create the archive *) ]
 
   type ('a, 'b) t

--- a/archive/ArchiveLow.ml
+++ b/archive/ArchiveLow.ml
@@ -25,6 +25,8 @@ type 'a skip_callback = 'a -> int -> int
 (* archive_read_open2 close callback *)
 type 'a close_callback = 'a -> unit
 
+type 'a seek_callback = 'a -> int -> Unix.seek_command -> int
+
 exception AEnd_of_file
 exception AFailure of error_code * string
 
@@ -67,6 +69,12 @@ module Read = struct
   external open_filename : t -> filename -> int -> unit
     = "caml_archive_read_open_filename"
   (** archive_read_open_filename *)
+
+  module Unsafe = struct
+    external set_seek_callback : t -> _ seek_callback -> unit
+      = "caml_archive_read_set_seek_callback"
+    (** archive_read_set_seek_callback *)
+  end
 
   external open2 :
     t ->

--- a/archive/Archive_stub.c
+++ b/archive/Archive_stub.c
@@ -368,7 +368,7 @@ CAMLprim int caml_archive_set_error (struct archive *ptr, value vres)
     if (Wosize_val(vexn) == 3 && Field(vexn, 0) == *caml_named_value("archive.failure"))
     {
       assert(Is_long(Field(vexn, 1)));
-      assert(Is_block(Field(vexn, 2) && Tag_val(Field(vexn, 2)) == String_tag));
+      assert(Is_block(Field(vexn, 2)) && Tag_val(Field(vexn, 2)) == String_tag);
       archive_set_error(ptr, Int_val(Field(vexn, 1)), "%s", String_val(Field(vexn, 2)));
     }
     else

--- a/archive/Archive_stub.c
+++ b/archive/Archive_stub.c
@@ -118,10 +118,12 @@ CAMLprim value caml_archive_entry_pathname (value ventry)
 {
   CAMLparam1(ventry);
   CAMLlocal1(vres);
-  /* TODO: check for null string */
-  vres =
-    caml_copy_string(
-      archive_entry_pathname(*Entry_val(ventry)));
+  const char *c = archive_entry_pathname(*Entry_val(ventry));
+  if (!c)
+    caml_raise_with_string
+      (*caml_named_value("archive.failure"),
+       "null pathname");
+  vres = caml_copy_string(c);
   CAMLreturn(vres);
 }
 

--- a/archive/Archive_stub.c
+++ b/archive/Archive_stub.c
@@ -578,6 +578,8 @@ CAMLprim value caml_archive_read_open2_native (
   CAMLxparam1(vdata);
   CAMLlocal1(vbuffer);
 
+  vbuffer = caml_alloc_string(READ_BUFFER);
+
   ptr = Archive_val(vread);
   read_cbk = ptr;
 
@@ -593,7 +595,7 @@ CAMLprim value caml_archive_read_open2_native (
   read_cbk->read_cbk  = vread_cbk;
   read_cbk->skip_cbk  = vskip_cbk;
   read_cbk->close_cbk = vclose_cbk;
-  read_cbk->buffer    = caml_alloc_string(READ_BUFFER);
+  read_cbk->buffer    = vbuffer;
   read_cbk->client_data = vdata;
   read_cbk->client_data2 = Val_unit;
 

--- a/archive/Archive_stub.c
+++ b/archive/Archive_stub.c
@@ -392,6 +392,8 @@ CAMLprim int caml_archive_open_callback2(struct archive *ptr, struct caml_archiv
   vres = caml_callback_exn(data->open_cbk, data->client_data);
   if (caml_archive_set_error(ptr, vres))
   {
+    data->close_cbk = Val_unit;
+    data->client_data2 = Val_unit;
     res = ARCHIVE_FATAL;
   }
   else
@@ -522,11 +524,14 @@ CAMLprim int caml_archive_close_callback2 (struct archive *ptr, struct caml_arch
 
   CAMLparam0();
   CAMLlocal1(res);
-  res = caml_callback_exn(data->close_cbk, data->client_data2);
-  if (caml_archive_set_error(ptr, res))
+  if (data->close_cbk != Val_unit)
   {
-    ret = ARCHIVE_FATAL;
-  };
+    res = caml_callback_exn(data->close_cbk, data->client_data2);
+    if (caml_archive_set_error(ptr, res))
+    {
+      ret = ARCHIVE_FATAL;
+    }
+  }
 
   CAMLreturnT(int, ret);
 };

--- a/test/test.ml
+++ b/test/test.ml
@@ -135,4 +135,16 @@ let ([] | _ :: _) =
              ListString.assert_equal ~msg:"_oasis content"
                (ExtLib.String.nsplit exp_dump "\n")
                (ExtLib.String.nsplit dump "\n") );
+           ( "NoCloseAfterFailedOpen" >:: fun () ->
+             let a = ArchiveLow.Read.create () in
+             let () =
+               try
+                 let boom () = raise (ArchiveLow.AFailure (42, "message")) in
+                 let z _ _ = 0 in
+                 ArchiveLow.Read.open2 a boom z z ignore ()
+                 (* if the test fails, open2 will SEGFAULT *)
+               with ArchiveLow.AFailure (code, msg) ->
+                 assert_equal (code, msg) (42, "message")
+             in
+             ArchiveLow.Read.close a );
          ])


### PR DESCRIPTION
Hi,

Thanks for your work. In an effort to implement remote archive traversal, I need to set a seek callback. However, I can't find a way to propagate a type parameter without changing `type 'a archive` and breaking compatibility. Would you be interested in such a patch?

Greetings,